### PR TITLE
Fix verification commands in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,7 +37,7 @@ An output similar to below will be displayed.
 Use the [Sigstore cosign](https://github.com/sigstore/cosign) tool to verify images have been signed using the [keyless method](https://docs.sigstore.dev/signing/overview/).
 
 ```sh
-cosign verify gcr.io/kubecost1/disk-autoscaler:$TAG --certificate-identity-regexp="https://github.com/kubecost1/disk-autoscaler/.github/workflows/release.yaml@refs/tags/*" --certificate-oidc-issuer="https://token.actions.githubusercontent.com" | jq
+cosign verify gcr.io/kubecost1/disk-autoscaler:$TAG --certificate-identity-regexp="https://github.com/kubecost/disk-autoscaler/.github/workflows/release.yaml@refs/tags/*" --certificate-oidc-issuer="https://token.actions.githubusercontent.com" | jq
 ```
 
 The image signature is also available as an offline release asset for every tagged release.
@@ -75,7 +75,7 @@ slsa-verifier verify-image gcr.io/kubecost1/disk-autoscaler@<digest> --source-ur
 Use the [Sigstore cosign](https://github.com/sigstore/cosign) tool to verify a software bill of materials (SBOM), using the [CycloneDX](https://cyclonedx.org/) standard, has been attested using the [keyless method](https://docs.sigstore.dev/signing/overview/).
 
 ```sh
-cosign verify-attestation --type cyclonedx gcr.io/kubecost1/disk-autoscaler:$TAG --certificate-identity-regexp="https://github.com/kubecost1/disk-autoscaler/.github/workflows/release.yaml@refs/tags/*" --certificate-oidc-issuer="https://token.actions.githubusercontent.com" | jq .payload -r | base64 --decode | jq
+cosign verify-attestation --type cyclonedx gcr.io/kubecost1/disk-autoscaler:$TAG --certificate-identity-regexp="https://github.com/kubecost/disk-autoscaler/.github/workflows/release.yaml@refs/tags/*" --certificate-oidc-issuer="https://token.actions.githubusercontent.com" | jq .payload -r | base64 --decode | jq
 ```
 
 The SBOM is also available as an offline release asset for every tagged release.
@@ -85,7 +85,7 @@ The SBOM is also available as an offline release asset for every tagged release.
 Verify the image scan results from [Trivy](https://github.com/aquasecurity/trivy).
 
 ```sh
-cosign verify-attestation --type vuln gcr.io/kubecost1/disk-autoscaler:$TAG --certificate-identity-regexp="https://github.com/kubecost1/disk-autoscaler/.github/workflows/release.yaml@refs/tags/*" --certificate-oidc-issuer="https://token.actions.githubusercontent.com" | jq .payload -r | base64 --decode | jq
+cosign verify-attestation --type vuln gcr.io/kubecost1/disk-autoscaler:$TAG --certificate-identity-regexp="https://github.com/kubecost/disk-autoscaler/.github/workflows/release.yaml@refs/tags/*" --certificate-oidc-issuer="https://token.actions.githubusercontent.com" | jq .payload -r | base64 --decode | jq
 ```
 
 The vulnerability scan is also available as an offline release asset for every tagged release.


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

Fixes the verification commands in SECURITY.md so they point to the correct GitHub repo.

## Does this PR rely on any other PRs?

No, fix from #16

## How does this PR impact users?

Allows them to successfully verify supply chain security artifacts via copy-and-paste.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->

Relates to PR #16

## What risks are associated with merging this PR? What is required to fully test this PR?

Instructions are still wrong.

## How was this PR tested?

Copied-and-pasted commands locally after first release run.