### PR TITLE
Audit mode with default true

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The following are the environment variables which may be passed to the disk auto
 | `DAS_KUBECONFIG`      | Path to the Kubeconfig to be used by the disk auto-scaler. | `/foo/bar` |
 | `DAS_LOG_LEVEL`       | Set the desired logging level of the disk auto-scaler. Defaults to `info` if not specified. | `debug` |
 | `DAS_EXCLUDE_NAMESPACES`| The namespaces are excluded from disk auto-scaling. It is recommended to include the kube-system namespace and the namespace where Kubecost is installed. This supports regular expressions. | `"kubecost,kube-*,openshift-*"`|
-| `DAS_AUDIT_MODE`| Read-Only run of Disk Auto Scaler, that provides recommended size of the PV associated with deployment using kubecost PV right sizing API also list the savings predicted by kubecost  | `true`|
+| `DAS_AUDIT_MODE`| Read-only execution of the Disk Auto Scaler, which offers recommended Persistent Volume (PV) sizes for deployments using the Kubecost PV right-sizing API, along with a list of cost savings predicted by Kubecost.| `true`|
 
 ### User-Configurable Annotations
 
@@ -133,3 +133,15 @@ Once disk auto-scaler performs a scaling operation, the following informational 
 | `request.autodiskscaling.kubecost.com/volumeCreatedBy`       | Acknowledgement that a volume was created.            | `kubecost_disk_auto_scaler` |
 | `request.autodiskscaling.kubecost.com/lastScaled`            | The time the volume was last scaled.                  | `2002-10-02T15:00:00Z` |
 
+### Audit Mode run
+
+In audit mode, the Disk Auto Scaler operates in a read-only mode. The logs contain information such as the namespace, deployment, Persistent Volume Claim (PVC), Physical Volume (PV), current size, recommended size, and monthly savings, as illustrated in the logs below.
+
+```
+2024-05-16T22:44:17Z INF Namespace: steven, Deployment: steven-prometheus-server, PVC: steven-prometheus-server, PV: pvc-8fb7e7f6-83ef-444a-b337-0c6698cc9f90, Target Utilization: 70%, current size is: 32Gi, recommended size is: 1Gi, and expected monthly savings is: $3.10
+2024-05-16T22:44:17Z INF Namespace: thanos, Deployment: thanos-compactor, PVC: thanos-compactor, PV: pvc-5f174e0f-8245-4023-880e-d44383ba4c2a, Target Utilization: 70%, current size is: 8Gi, recommended size is: 1Gi, and expected monthly savings is: $0.70
+2024-05-16T22:44:19Z INF Namespace: disk-scaler-demo, Deployment: ubuntu-deployment-scale-up, PVC: scale-up-pvc, PV: pvc-bd21b08e-7f68-4798-b1db-16577a5d9772, Target Utilization: 70%, current size is: 6Gi, recommended size is: 6Gi, and expected monthly savings is: $-0.08
+2024-05-16T22:44:19Z INF Namespace: thomasn-guardduty-tmp, Deployment: thomasn-guardduty-tmp-cost-analyzer, PVC: thomasn-guardduty-tmp-cost-analyzer, PV: pvc-589ada18-bd52-41e6-a768-a2da2e12e67d, Target Utilization: 70%, current size is: 32Gi, recommended size is: 2Gi, and expected monthly savings is: $3.00
+2024-05-16T22:44:20Z INF Namespace: thomasn-guardduty-tmp, Deployment: thomasn-guardduty-tmp-prometheus-server, PVC: thomasn-guardduty-tmp-prometheus-server, PV: pvc-7f3bde56-5ad0-43bb-b7a7-61e6878200d9, Target Utilization: 70%, current size is: 32Gi, recommended size is: 1Gi, and expected monthly savings is: $3.10
+2024-05-16T22:44:21Z INF Namespace: ecr-test, Deployment: ecr-test-cost-analyzer, PVC: ecr-test-cost-analyzer, PV: pvc-cfa8a9c3-88e6-4bbc-8511-9bdeb5e89141, Target Utilization: 70%, current size is: 32Gi, recommended size is: 1Gi, and expected monthly savings is: $3.10
+2024-05-16T22:44:21Z INF Namespace: thomasn-nightly-dev, Deployment: thomasn-nightly-dev-cost-analyzer, PVC: thomasn-nightly-dev-cost-analyzer, PV: pvc-691a99a8-ad61-4432-b125-fd136e8de168, Target Utilization: 70%, current size is: 32Gi, recommended size is: 2Gi, and expected monthly savings is: $3.00```

--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ See [here](https://docs.kubecost.com/install-and-configure/install) for the full
 
 4. Disk Auto-Scaler will automatically scan the cluster for the annotations above and scale the disks accordingly. Disk Auto-Scaler will re-check every hour for changes in utilization and scale if needed.
 
+### Audit Mode
+
+By default, Disk Auto-Scaler runs in audit mode which allows you to assess the changes it would make rather than having it proceed with any such changes. In this mode, it will print the pertinent information about a potential resizing action in the logs along with the savings achieved as a result as shown in the log snippet below.
+
+```log
+2024-05-16T22:44:21Z INF Namespace: thomasn-nightly-dev, Deployment: thomasn-nightly-dev-cost-analyzer, PVC: thomasn-nightly-dev-cost-analyzer, PV: pvc-691a99a8-ad61-4432-b125-fd136e8de168, Target Utilization: 70%, current size is: 32Gi, recommended size is: 2Gi, and expected monthly savings is: $3.00
+```
+
+To disable the default audit mode, change the value of the `DAS_AUDIT_MODE` environment variable to `"false"` and Disk Auto-Scaler will perform the resizing operations automatically.
+
 For an example StorageClass resource which is supported by Disk Autoscaler, please see [here](aws/gp3-storageClass.yaml).
 
 ### Scaling Up
@@ -79,7 +89,7 @@ The following are the environment variables which may be passed to the Disk Auto
 | `DAS_KUBECONFIG`      | Path to the Kubeconfig to be used by the disk auto-scaler. | `/foo/bar` |
 | `DAS_LOG_LEVEL`       | Set the desired logging level of the disk auto-scaler. Defaults to `info` if not specified. | `debug` |
 | `DAS_EXCLUDE_NAMESPACES`| The namespaces are excluded from disk auto-scaling. It is recommended to include the kube-system namespace and the namespace where Kubecost is installed. This supports regular expressions. | `"kubecost,kube-*,openshift-*"`|
-| `DAS_AUDIT_MODE`| Read-only execution of the Disk Auto Scaler, which offers recommended Persistent Volume (PV) sizes for deployments using the Kubecost PV right-sizing API, along with a list of cost savings predicted by Kubecost.| `true`|
+| `DAS_AUDIT_MODE`| Read-only execution of the Disk Auto Scaler, which offers recommended Persistent Volume (PV) sizes for deployments using the Kubecost PV right-sizing API, along with a list of cost savings predicted by Kubecost.| `"true"`|
 
 ## Annotations
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The following are the environment variables which may be passed to the disk auto
 | `DAS_KUBECONFIG`      | Path to the Kubeconfig to be used by the disk auto-scaler. | `/foo/bar` |
 | `DAS_LOG_LEVEL`       | Set the desired logging level of the disk auto-scaler. Defaults to `info` if not specified. | `debug` |
 | `DAS_EXCLUDE_NAMESPACES`| The namespaces are excluded from disk auto-scaling. It is recommended to include the kube-system namespace and the namespace where Kubecost is installed. This supports regular expressions. | `"kubecost,kube-*,openshift-*"`|
+| `DAS_AUDIT_MODE`| Read-Only run of Disk Auto Scaler, that provides recommended size of the PV associated with deployment using kubecost PV right sizing API also list the savings predicted by kubecost  | `true`|
 
 ### User-Configurable Annotations
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ When scaling down, Disk Auto-Scaler decreases the size of a given PVC. To do thi
 * Only `WaitForFirstConsumer` is supported leveraging Kubernetes deploying PersistentVolume on the same node as the original PV backing the PVC.
 * Storage class with driver `ebs.csi.aws.com` only supports the `ReadWriteOnce` access mode.
 
-### Environment Variables
+## Environment Variables
 
-The following are the environment variables which may be passed to the disk auto-scaler container along with a description and an example value.
+The following are the environment variables which may be passed to the Disk Auto-Scaler container along with a description and an example value.
 
 | Env Var               | Description | Example(s) |
 | --------------------- | ----------- | ------- |
@@ -80,6 +80,8 @@ The following are the environment variables which may be passed to the disk auto
 | `DAS_LOG_LEVEL`       | Set the desired logging level of the disk auto-scaler. Defaults to `info` if not specified. | `debug` |
 | `DAS_EXCLUDE_NAMESPACES`| The namespaces are excluded from disk auto-scaling. It is recommended to include the kube-system namespace and the namespace where Kubecost is installed. This supports regular expressions. | `"kubecost,kube-*,openshift-*"`|
 | `DAS_AUDIT_MODE`| Read-only execution of the Disk Auto Scaler, which offers recommended Persistent Volume (PV) sizes for deployments using the Kubecost PV right-sizing API, along with a list of cost savings predicted by Kubecost.| `true`|
+
+## Annotations
 
 ### User-Configurable Annotations
 
@@ -133,15 +135,3 @@ Once disk auto-scaler performs a scaling operation, the following informational 
 | `request.autodiskscaling.kubecost.com/volumeCreatedBy`       | Acknowledgement that a volume was created.            | `kubecost_disk_auto_scaler` |
 | `request.autodiskscaling.kubecost.com/lastScaled`            | The time the volume was last scaled.                  | `2002-10-02T15:00:00Z` |
 
-### Audit Mode run
-
-In audit mode, the Disk Auto Scaler operates in a read-only mode. The logs contain information such as the namespace, deployment, Persistent Volume Claim (PVC), Physical Volume (PV), current size, recommended size, and monthly savings, as illustrated in the logs below.
-
-```
-2024-05-16T22:44:17Z INF Namespace: steven, Deployment: steven-prometheus-server, PVC: steven-prometheus-server, PV: pvc-8fb7e7f6-83ef-444a-b337-0c6698cc9f90, Target Utilization: 70%, current size is: 32Gi, recommended size is: 1Gi, and expected monthly savings is: $3.10
-2024-05-16T22:44:17Z INF Namespace: thanos, Deployment: thanos-compactor, PVC: thanos-compactor, PV: pvc-5f174e0f-8245-4023-880e-d44383ba4c2a, Target Utilization: 70%, current size is: 8Gi, recommended size is: 1Gi, and expected monthly savings is: $0.70
-2024-05-16T22:44:19Z INF Namespace: disk-scaler-demo, Deployment: ubuntu-deployment-scale-up, PVC: scale-up-pvc, PV: pvc-bd21b08e-7f68-4798-b1db-16577a5d9772, Target Utilization: 70%, current size is: 6Gi, recommended size is: 6Gi, and expected monthly savings is: $-0.08
-2024-05-16T22:44:19Z INF Namespace: thomasn-guardduty-tmp, Deployment: thomasn-guardduty-tmp-cost-analyzer, PVC: thomasn-guardduty-tmp-cost-analyzer, PV: pvc-589ada18-bd52-41e6-a768-a2da2e12e67d, Target Utilization: 70%, current size is: 32Gi, recommended size is: 2Gi, and expected monthly savings is: $3.00
-2024-05-16T22:44:20Z INF Namespace: thomasn-guardduty-tmp, Deployment: thomasn-guardduty-tmp-prometheus-server, PVC: thomasn-guardduty-tmp-prometheus-server, PV: pvc-7f3bde56-5ad0-43bb-b7a7-61e6878200d9, Target Utilization: 70%, current size is: 32Gi, recommended size is: 1Gi, and expected monthly savings is: $3.10
-2024-05-16T22:44:21Z INF Namespace: ecr-test, Deployment: ecr-test-cost-analyzer, PVC: ecr-test-cost-analyzer, PV: pvc-cfa8a9c3-88e6-4bbc-8511-9bdeb5e89141, Target Utilization: 70%, current size is: 32Gi, recommended size is: 1Gi, and expected monthly savings is: $3.10
-2024-05-16T22:44:21Z INF Namespace: thomasn-nightly-dev, Deployment: thomasn-nightly-dev-cost-analyzer, PVC: thomasn-nightly-dev-cost-analyzer, PV: pvc-691a99a8-ad61-4432-b125-fd136e8de168, Target Utilization: 70%, current size is: 32Gi, recommended size is: 2Gi, and expected monthly savings is: $3.00```

--- a/cmd/diskautoscaler/main.go
+++ b/cmd/diskautoscaler/main.go
@@ -23,6 +23,8 @@ import (
 const (
 	envPrefix    = "das"
 	logLevelConf = "log_level"
+	dasBurst     = 10
+	dasQPS       = 20
 )
 
 func initK8sRest() (*rest.Config, error) {
@@ -64,6 +66,8 @@ func initK8sRest() (*rest.Config, error) {
 				Str("path", kubeconfigPath).
 				Msgf("Built K8s config from local config")
 		}
+		config.QPS = dasQPS
+		config.Burst = dasBurst
 
 		return config, nil
 	}

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -68,6 +68,8 @@ spec:
               value: http://kubecost-cost-analyzer.kubecost:9090/model
             - name: DAS_EXCLUDE_NAMESPACES
               value: "kubecost,kube-*,openshift-*"
+            - name: DAS_AUDIT_MODE
+              value: "true"
           image: gcr.io/kubecost1/disk-autoscaler:latest
           imagePullPolicy: IfNotPresent
           name: disk-autoscaler

--- a/pkg/diskscaler/diskscaler.go
+++ b/pkg/diskscaler/diskscaler.go
@@ -368,7 +368,7 @@ func (ds *DiskScaler) getPVCMap(ctx context.Context, namespace string, deploymen
 	for _, vol := range volumes {
 		if vol.PersistentVolumeClaim == nil {
 			// The PVC name is required even when in audit mode so we continue and don't provide any recommendation or err logs
-			// this condition is typical encountered when we have ephemeral storage. i.e storage tied to pod lifecyle.
+			// this condition is typically encountered when we have ephemeral storage, i.e storage tied to pod lifecyle.
 			if ds.auditMode {
 				continue
 			}

--- a/pkg/diskscaler/diskscaler.go
+++ b/pkg/diskscaler/diskscaler.go
@@ -92,7 +92,7 @@ func (ds *DiskScaler) runDiskScalingWorkflow(ctx context.Context, namespace, dep
 		return fmt.Errorf("disk scaling failed : %w", err)
 	}
 
-	// No further action is needed if its audit mode
+	// No further action is needed if audit mode is enabled
 	if ds.auditMode {
 		return nil
 	}

--- a/pkg/diskscaler/diskscaler.go
+++ b/pkg/diskscaler/diskscaler.go
@@ -367,7 +367,7 @@ func (ds *DiskScaler) getPVCMap(ctx context.Context, namespace string, deploymen
 	volumes := v1Dep.Spec.Template.Spec.Volumes
 	for _, vol := range volumes {
 		if vol.PersistentVolumeClaim == nil {
-			// The PV claim name is required even thou it's audit mode so we continue and not provide any recommendation or err logs
+			// The PVC name is required even when in audit mode so we continue and don't provide any recommendation or err logs
 			// this condition is typical encountered when we have ephemeral storage. i.e storage tied to pod lifecyle.
 			if ds.auditMode {
 				continue

--- a/pkg/diskscaler/diskscaler.go
+++ b/pkg/diskscaler/diskscaler.go
@@ -387,7 +387,7 @@ func (ds *DiskScaler) getPVCMap(ctx context.Context, namespace string, deploymen
 
 		pvName := k8sPVCInfo.Spec.VolumeName
 
-		// CHeck to see if pv is not hostpath mounted, Kubecost doesnt provide recommendation to hostpath mounts at this time.
+		// Check to see if PV is not hostPath mounted. Kubecost doesn't provide recommendations for hostPath mounts at this time.
 		// i.e volume mounted on node itself rather than a Physical volume.
 		pvInfo, err := ds.getPVInfo(ctx, pvName)
 		if err != nil {

--- a/pkg/diskscaler/diskscaler.go
+++ b/pkg/diskscaler/diskscaler.go
@@ -378,7 +378,7 @@ func (ds *DiskScaler) getPVCMap(ctx context.Context, namespace string, deploymen
 		pvcName := vol.PersistentVolumeClaim.ClaimName
 		k8sPVCInfo, err := ds.getPVCInfo(ctx, namespace, pvcName)
 		if err != nil {
-			// The PVC information is required even thou it's audit mode so we continue and not provide any recommendation or err logs
+			// The PVC information is required even when in audit mode so we continue and don't provide any recommendations or err logs
 			if ds.auditMode {
 				continue
 			}

--- a/pkg/diskscaler/error.go
+++ b/pkg/diskscaler/error.go
@@ -14,7 +14,7 @@ type DiskScalingAllFailedError struct {
 }
 
 func (e *DiskScalingAllFailedError) Error() string {
-	return fmt.Sprintf("failed to scale all the persistent volume claims in deployment %s belonging to namespace %s", e.namespace, e.deployment)
+	return fmt.Sprintf("failed to scale all the persistent volume claims in deployment %s belonging to namespace %s", e.deployment, e.namespace)
 }
 
 // Custom error to return to the service calling the
@@ -26,5 +26,5 @@ type DiskScalingPartialFailedError struct {
 }
 
 func (e *DiskScalingPartialFailedError) Error() string {
-	return fmt.Sprintf("failed to scale persistent volume claims %s in deployment %s belonging to namespace %s", strings.Join(e.pvc, ","), e.namespace, e.deployment)
+	return fmt.Sprintf("failed to scale persistent volume claims %s in deployment %s belonging to namespace %s", strings.Join(e.pvc, ","), e.deployment, e.namespace)
 }

--- a/pkg/diskscaler/service.go
+++ b/pkg/diskscaler/service.go
@@ -209,7 +209,7 @@ func (dss *DiskScalerService) startAutomatedScaling() error {
 				log.Debug().Msgf("No workloads have autoscaling enabled at %s", diskAutoScalerRun)
 			}
 			if status.NumEligible == 0 {
-				log.Debug().Msgf("No workload with autoscaling enabled can be resized again yet at %s", diskAutoScalerRun)
+				log.Debug().Msgf("No workload with autoscaling eligible at %s", diskAutoScalerRun)
 			}
 		}
 	}()

--- a/pkg/pvsizingrecommendation/query.go
+++ b/pkg/pvsizingrecommendation/query.go
@@ -10,30 +10,53 @@ import (
 	"path"
 	"regexp"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/rs/zerolog/log"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 const (
-	oneGiBytes            = 1024.0 * 1024.0 * 1024.0
-	supportedStorageRegex = "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-	equalityThreshold     = 0.00001
+	oneGiBytes                 = 1024.0 * 1024.0 * 1024.0
+	supportedStorageRegex      = "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+	equalityThreshold          = 0.00001
+	cacheRefresh               = 10 * time.Minute
+	overwriteTargetUtilization = 70
 )
 
 type KubecostService struct {
 	clusterInfoApiPath    string
 	recommendationApiPath string
+	cache                 map[string][]byte
+	mu                    sync.Mutex
 }
 
 func NewKubecostService(modelPath string) *KubecostService {
 	modelPath = strings.TrimSuffix(modelPath, "/")
-
+	cache := make(map[string][]byte)
 	svc := &KubecostService{
 		clusterInfoApiPath:    fmt.Sprintf("%s/%s", modelPath, path.Join("clusterInfo")),
 		recommendationApiPath: fmt.Sprintf("%s/%s", modelPath, path.Join("savings", "persistentVolumeSizing")),
+		cache:                 cache,
 	}
+	ticker := time.NewTicker(cacheRefresh)
+	go func() {
+		for {
+			for t := time.Now(); ; t = <-ticker.C {
+				log.Trace().Msgf("refreshing cache storing kubecost response at %s", t.String())
+				svc.refreshCache()
+			}
+		}
+	}()
 	return svc
+}
+
+// refreshCache refreshes the cache storing kubecost pv savings recommendation
+func (krs *KubecostService) refreshCache() {
+	krs.mu.Lock()
+	defer krs.mu.Unlock()
+	krs.cache = make(map[string][]byte, 0)
 }
 
 // CheckAvailable returns nil if the service is available to handle requests.
@@ -67,19 +90,83 @@ type RecResponse struct {
 }
 
 type PVRecommendation struct {
-	VolumeName           string  `json:"volumeName"`
-	AverageUsageBytes    float64 `json:"averageUsageBytes"`
-	CurrentCapacityBytes float64 `json:"currentCapacityBytes"`
+	VolumeName               string  `json:"volumeName"`
+	AverageUsageBytes        float64 `json:"averageUsageBytes"`
+	CurrentCapacityBytes     float64 `json:"currentCapacityBytes"`
+	RecommendedCapacityBytes float64 `json:"recommendedCapacityBytes"`
+	SavingsMonthly           float64 `json:"savingsMonthly"`
 }
 
-func (krs *KubecostService) GetRecommendation(ctx context.Context, pvName string, targetUtilization int, interval string) (resource.Quantity, error) {
+type RecommendationSizeWithSavings struct {
+	RecommendedResourceSize resource.Quantity
+	Savings                 float64
+}
+
+func (krs *KubecostService) GetRecommendation(ctx context.Context, pvName string, targetUtilization int, interval string) (RecommendationSizeWithSavings, error) {
+	ohPercentage := computeOverHeadPercentForTargetUtilization(targetUtilization)
+	recommendation := RecommendationSizeWithSavings{}
+	respBody, err := krs.getFromCacheOrFetch(interval, ohPercentage)
+	if err != nil {
+		return recommendation, fmt.Errorf("failed to fetch pv recommendation from kubecost: %w", err)
+	}
+
+	var recResp RecResponse
+	err = json.Unmarshal(respBody, &recResp)
+	if err != nil {
+		return recommendation, fmt.Errorf("unable to parse the response from kubecost")
+	}
+	var recommendedBytes float64
+	var savingsMonthly float64
+	for _, pvRecommendation := range recResp.Recommendation {
+		// Make sure that the recommended bytes is 70% utilization of current average usage byte compute from kubecost
+		if pvRecommendation.VolumeName == pvName {
+			recommendedBytes = pvRecommendation.RecommendedCapacityBytes
+			savingsMonthly = pvRecommendation.SavingsMonthly
+		}
+	}
+
+	// Happens when the storage provisioned but kubecost hasnt recieved data
+	if almostEqual(recommendedBytes, 0.0) {
+		return recommendation, fmt.Errorf("unable to find accurate utilization from kubecost at this time")
+	}
+
+	// 1 Gi is the smallest storage size in AWS EBS
+	// ref : https://kubernetes.io/docs/tasks/administer-cluster/limit-storage-consumption/#limitrange-to-limit-requests-for-storage
+	if recommendedBytes < oneGiBytes {
+		log.Debug().Msgf("recommendedBytes from kubecost %f[in Bytes] is less than 1 Gi, defaulting to 1 Gi, since minimal storage provision is 1Gi", recommendedBytes)
+		recommendation.RecommendedResourceSize = resource.MustParse("1Gi")
+		recommendation.Savings = savingsMonthly
+		return recommendation, nil
+	}
+
+	recommendedSize, err := convertKubecostBytesToStorageRecommendation(recommendedBytes / oneGiBytes)
+	if err != nil {
+		return recommendation, fmt.Errorf("failed to convert kubecost bytes recommendation to storage request: %w", err)
+	}
+	recommendation.RecommendedResourceSize = recommendedSize
+	recommendation.Savings = savingsMonthly
+
+	return recommendation, nil
+}
+
+// getFromCacheOrFetch fetches from cache instead of repeated calling kubecost pvsizing recommendation end point
+func (krs *KubecostService) getFromCacheOrFetch(window string, overheadPercent string) ([]byte, error) {
+	krs.mu.Lock()
+	defer krs.mu.Unlock()
+
+	cacheKey := window
+	if content, ok := krs.cache[window]; ok {
+		return content, nil
+	}
+
 	queryParams := map[string]string{
-		"window": interval,
+		"window":          window,
+		"overheadPercent": overheadPercent,
 	}
 
 	req, err := http.NewRequest("GET", krs.recommendationApiPath, nil)
 	if err != nil {
-		return resource.Quantity{}, fmt.Errorf("making request: %s", err)
+		return []byte{}, fmt.Errorf("making request: %s", err)
 	}
 	q := req.URL.Query()
 	for k, v := range queryParams {
@@ -89,45 +176,24 @@ func (krs *KubecostService) GetRecommendation(ctx context.Context, pvName string
 	log.Debug().
 		Str("url", req.URL.String()).
 		Msgf("Request recommendation")
+
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return resource.Quantity{}, fmt.Errorf("executing query: %w", err)
+		return []byte{}, fmt.Errorf("executing query: %w", err)
 	}
 	defer resp.Body.Close()
 	respBody, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return resource.Quantity{}, fmt.Errorf("reading response body: %s", err)
+		return []byte{}, fmt.Errorf("reading response body: %s", err)
 	}
+
 	if resp.StatusCode != http.StatusOK {
-		return resource.Quantity{}, fmt.Errorf("non-OK response status (%d), body: %s", resp.StatusCode, string(respBody))
-	}
-	var recResp RecResponse
-	err = json.Unmarshal(respBody, &recResp)
-	if err != nil {
-		return resource.Quantity{}, fmt.Errorf("unable to parse the response from kubecost")
-	}
-	var recommendedBytes float64
-	for _, pvRecommendation := range recResp.Recommendation {
-		// Make sure that the recommended bytes is 70% utilization of current average usage byte compute from kubecost
-		if pvRecommendation.VolumeName == pvName {
-			recommendedBytes = pvRecommendation.AverageUsageBytes / (float64(targetUtilization) / 100.0)
-		}
+		return []byte{}, fmt.Errorf("non-OK response status (%d), body: %s", resp.StatusCode, string(respBody))
 	}
 
-	// Happens when the storage provisioned but kubecost hasnt recieved data
-	if almostEqual(recommendedBytes, 0.0) {
-		return resource.Quantity{}, fmt.Errorf("unable to find accurate utilization from kubecost at this time")
-	}
-
-	// 1 Gi is the smallest storage size in AWS EBS
-	// ref : https://kubernetes.io/docs/tasks/administer-cluster/limit-storage-consumption/#limitrange-to-limit-requests-for-storage
-	if recommendedBytes < oneGiBytes {
-		log.Warn().Msgf("recommendedBytes from kubecost %f[in Bytes] is less than 1 Gi, defaulting to 1 Gi, since minimal storage provision is 1Gi", recommendedBytes)
-		return resource.MustParse("1Gi"), nil
-	}
-
-	return convertKubecostBytesToStorageRecommendation(recommendedBytes / oneGiBytes)
+	krs.cache[cacheKey] = respBody
+	return respBody, nil
 }
 
 // convertKubecostBytesToStorageRecommendation converts the byte recommendation
@@ -153,6 +219,18 @@ func convertKubecostBytesToStorageRecommendation(bf float64) (resource.Quantity,
 	}
 	return resource.MustParse(recommendedStorageStr), nil
 }
+
+// Kubecost PV right sizing API takes overhead percentage, the 70% utilization i.e 70 in 100 is
+// 100 in 100+[30/70] equivalent. This function perform the conversion to parameter taken by kubecost.
+func computeOverHeadPercentForTargetUtilization(tu int) string {
+	// If user provides 0 in target utilization overwrite to 70% target utilization
+	if tu == 0 {
+		tu = overwriteTargetUtilization
+	}
+	overheadPercent := (float64(100-tu) / float64(tu) * 100)
+	return fmt.Sprintf("%.2f", overheadPercent)
+}
+
 func almostEqual(val1, val2 float64) bool {
 	return math.Abs(val1-val2) <= equalityThreshold
 }

--- a/pkg/pvsizingrecommendation/query_test.go
+++ b/pkg/pvsizingrecommendation/query_test.go
@@ -102,3 +102,40 @@ func Test_convertKubecostBytesToStorageRecommendation(t *testing.T) {
 		}
 	}
 }
+
+func Test_computeOverHeadPercentForTargetUtilization(t *testing.T) {
+	type testCase struct {
+		name                    string
+		targetUtilization       int
+		expectedOverHeadpercent string
+	}
+
+	testCases := []testCase{
+		{
+			name:                    "when target utilization is 70, equivalent overhead percentage in kubecost",
+			targetUtilization:       70,
+			expectedOverHeadpercent: "42.86",
+		},
+		{
+			name:                    "when target utilization is 80, equivalent overhead percentage in kubecost",
+			targetUtilization:       80,
+			expectedOverHeadpercent: "25.00",
+		},
+		{
+			name:                    "when target utilization is 100, equivalent overhead percentage in kubecost",
+			targetUtilization:       100,
+			expectedOverHeadpercent: "0.00",
+		},
+		{
+			name:                    "when target utilization is 0, equivalent overhead percentage in kubecost",
+			targetUtilization:       0,
+			expectedOverHeadpercent: "42.86",
+		},
+	}
+	for _, tc := range testCases {
+		returnOverHeadpercent := computeOverHeadPercentForTargetUtilization(tc.targetUtilization)
+		if returnOverHeadpercent != tc.expectedOverHeadpercent {
+			t.Fatalf("test case %s: expectedOverHeadpercent %s but received %s", tc.name, tc.expectedOverHeadpercent, returnOverHeadpercent)
+		}
+	}
+}


### PR DESCRIPTION
## What does this PR change?
1. Introduces audit mode run for Disk auto scaler
2. adds caching in front of API call to Kubecost API
3. Recommended bytes is calculated by convert targetutilization to headroom percentage expected by kubecost API
4. Interchanges namespace and deployment in custom error.
5. Kubernetes REST client settings are set to Queries per second of 20 and Burst of 10. This is still low to avoid log message having Kubernetes request.go warning about waiting to get the kubernetes object.

## Does this PR rely on any other PRs?
None

## How does this PR impact users?
Default will be audit mode, unless it set to false the Disk auto scaling wouldnt perform any scaling up and scaling down operations

## Links to Issues or tickets this PR addresses or fixes
closes #4 
<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->

## What risks are associated with merging this PR? What is required to fully test this PR?

The audit mode is a safe option as default so its better for user

## How was this PR tested?
When run in audit mode logs will look like below

```2024-05-16T22:44:16Z INF Namespace: pod-identity, Deployment: pod-identity-prometheus-server, PVC: pod-identity-prometheus-server, PV: pvc-76755d3d-f0bf-4b7d-8fad-f4522609fb6b, Target Utilization: 70%, current size is: 32Gi, recommended size is: 1Gi, and expected monthly savings is: $3.10
2024-05-16T22:44:17Z INF Namespace: steven, Deployment: steven-prometheus-server, PVC: steven-prometheus-server, PV: pvc-8fb7e7f6-83ef-444a-b337-0c6698cc9f90, Target Utilization: 70%, current size is: 32Gi, recommended size is: 1Gi, and expected monthly savings is: $3.10
2024-05-16T22:44:17Z INF Namespace: thanos, Deployment: thanos-compactor, PVC: thanos-compactor, PV: pvc-5f174e0f-8245-4023-880e-d44383ba4c2a, Target Utilization: 70%, current size is: 8Gi, recommended size is: 1Gi, and expected monthly savings is: $0.70
2024-05-16T22:44:19Z INF Namespace: disk-scaler-demo, Deployment: ubuntu-deployment-scale-up, PVC: scale-up-pvc, PV: pvc-bd21b08e-7f68-4798-b1db-16577a5d9772, Target Utilization: 70%, current size is: 6Gi, recommended size is: 6Gi, and expected monthly savings is: $-0.08
2024-05-16T22:44:19Z INF Namespace: thomasn-guardduty-tmp, Deployment: thomasn-guardduty-tmp-cost-analyzer, PVC: thomasn-guardduty-tmp-cost-analyzer, PV: pvc-589ada18-bd52-41e6-a768-a2da2e12e67d, Target Utilization: 70%, current size is: 32Gi, recommended size is: 2Gi, and expected monthly savings is: $3.00
2024-05-16T22:44:20Z INF Namespace: thomasn-guardduty-tmp, Deployment: thomasn-guardduty-tmp-prometheus-server, PVC: thomasn-guardduty-tmp-prometheus-server, PV: pvc-7f3bde56-5ad0-43bb-b7a7-61e6878200d9, Target Utilization: 70%, current size is: 32Gi, recommended size is: 1Gi, and expected monthly savings is: $3.10
2024-05-16T22:44:21Z INF Namespace: ecr-test, Deployment: ecr-test-cost-analyzer, PVC: ecr-test-cost-analyzer, PV: pvc-cfa8a9c3-88e6-4bbc-8511-9bdeb5e89141, Target Utilization: 70%, current size is: 32Gi, recommended size is: 1Gi, and expected monthly savings is: $3.10
2024-05-16T22:44:21Z INF Namespace: thomasn-nightly-dev, Deployment: thomasn-nightly-dev-cost-analyzer, PVC: thomasn-nightly-dev-cost-analyzer, PV: pvc-691a99a8-ad61-4432-b125-fd136e8de168, Target Utilization: 70%, current size is: 32Gi, recommended size is: 2Gi, and expected monthly savings is: $3.00
```

Without audit mode tested for scale up and scale down operation 

