### PR TITLE
Justfile to reflect ko build and add commit hash and version to the DAS container

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,6 +58,8 @@ jobs:
       # IMAGE will be in format <registry>/<org>/<repo>@<digest> ex ghcr.io/johndoe/redis@sha256:1b85db3f261af51914867eeda20a25bedf72fa406619bcdd60f0658f27b2722d
       run: |
         tag=$(echo ${{ github.ref }} | cut -c11-)
+        export VERSION=$tag
+        export COMMIT_HASH=${{ github.sha }}
         IMAGE=$(ko build ./cmd/diskautoscaler --bare -t latest -t ${{ github.sha }} -t ${tag} --sbom=cyclonedx --sbom-dir=./)
         echo "The image generated is: $IMAGE"
         echo "## Image summary" >> $GITHUB_STEP_SUMMARY

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -3,6 +3,7 @@ builds:
   dir: ./cmd/diskautoscaler
   main: .
   ldflags:
-  - -s -w 
+  - -s
+  - -w
   - -X "main.CommitHash={{.Env.COMMIT_HASH}}"
   - -X "main.Version={{.Env.VERSION}}"

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -3,4 +3,6 @@ builds:
   dir: ./cmd/diskautoscaler
   main: .
   ldflags:
-  - -s -w
+  - -s -w 
+  - -X "main.CommitHash={{.Env.COMMIT_HASH}}"
+  - -X "main.Version={{.Env.VERSION}}"

--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,5 @@
 nocgo := "CGO_ENABLED=0"
-
+localbuild := "build_locally"
 default:
     just --list
 
@@ -12,7 +12,7 @@ test-das:
 # user still has to configure KO_DOCKER_REPO for the destination of ko build image
 # please refer https://ko.build/get-started/
 ko-build VERSION:
-    COMMIT_HASH=$(git rev-parse HEAD) VERSION={{VERSION}} \
+    COMMIT_HASH=$(git rev-parse HEAD) VERSION={{localbuild}} \
     ko build \
     ./cmd/diskautoscaler \
     --bare -t {{VERSION}}

--- a/Justfile
+++ b/Justfile
@@ -9,15 +9,11 @@ check-das:
 test-das:
     {{nocgo}} go test ./...
 
-# Need to refactor this recipe to use ko
-# dev-build TAG: check-das test-das
-#     docker buildx build \
-#     --rm \
-#     --platform "linux/amd64" \
-#     -f ./Dockerfile \
-#     --provenance=false \
-#     --load \
-#     -t {{TAG}} \
-#     .
-
-#     echo "Built: {{TAG}}"
+# user still has to configure KO_DOCKER_REPO for the destination of ko build image
+# please refer https://ko.build/get-started/
+ko-build VERSION:
+    COMMIT_HASH=$(git rev-parse HEAD) VERSION={{VERSION}} \
+    ko build \
+    ./cmd/diskautoscaler \
+    --bare -t {{VERSION}}
+    echo "Built: {{VERSION}}"

--- a/cmd/diskautoscaler/main.go
+++ b/cmd/diskautoscaler/main.go
@@ -27,6 +27,8 @@ const (
 	dasQPS       = 20
 )
 
+var CommitHash, Version string
+
 func initK8sRest() (*rest.Config, error) {
 	// Try to acquire an in-cluster config first
 	if config, err := rest.InClusterConfig(); err == nil {
@@ -74,6 +76,7 @@ func initK8sRest() (*rest.Config, error) {
 }
 
 func main() {
+	log.Info().Msgf("Running Disk Auto Scaler version: %s commitHash: %s", Version, CommitHash)
 	zerolog.TimeFieldFormat = time.RFC3339
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339})
 


### PR DESCRIPTION
## What does this PR change?
Adds the commit hash and version to the container instance running DAS to identify the source.
Fixes the justfile

## Does this PR rely on any other PRs?
None

## How does this PR impact users?
Minimal , just log message print

## Links to Issues or tickets this PR addresses or fixes
Closes #17 
Closes #18  
<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->


## What risks are associated with merging this PR? What is required to fully test this PR?
None

## How was this PR tested?
Created image : COMMIT_HASH=$(git rev-parse HEAD) VERSION=v0.007 ko build ./cmd/diskautoscaler --bare -t v0.007

WHile running the DAS container i get log
```
{"level":"info","time":"2024-05-17T22:39:04Z","message":"Running Disk Auto Scaler version: v0.007 commitHash: 1fe1bbddce1e22b3eb78fec16a6cb2fb6d0b9282"}
```

