### PR TITLE
Use chainguard dev image and set Pod Security Standard to restricted profile for the Kubecost copier

### DIFF
--- a/cmd/diskautoscaler/main.go
+++ b/cmd/diskautoscaler/main.go
@@ -119,7 +119,7 @@ func main() {
 
 	mux := http.NewServeMux()
 
-	err = diskscaler.Setup(mux, k8sRest, baseK8sClient, dynamicK8sClient)
+	err = diskscaler.Setup(mux, k8sRest, baseK8sClient, dynamicK8sClient, Version)
 	if err != nil {
 		log.Error().Err(err).Msgf("Kubescaler setup failed")
 	}

--- a/pkg/diskscaler/copier.yaml
+++ b/pkg/diskscaler/copier.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .PodName }}
+  namespace: {{ .Namespace }}
+  labels:
+    app.kubernetes.io/name: {{.Name }}
+    app.kubernetes.io/instance: {{ .PodName }}
+    app.kubernetes.io/version: {{ .Version }}
+    app.kubernetes.io/component: {{ .Component }}
+    app.kubernetes.io/part-of: {{ .PartOf }}
+    app.kubernetes.io/managed-by: {{ .Service }}
+spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    runAsUser: {{ .RunAsUser }}
+  containers:
+    - name: {{ .ContainerName }}
+      image: {{ .Image }}
+      command: ["/bin/sh", "-c", "--"]
+      args: ["sleep infinity"]
+      securityContext:
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumeMounts:
+        - name: orig-vol-mount
+          mountPath: /oldData
+        - name: backup-vol-mount
+          mountPath: /newData
+  volumes:
+    - name: orig-vol-mount
+      persistentVolumeClaim:
+        claimName: {{.OriginalPVC}}
+    - name: backup-vol-mount
+      persistentVolumeClaim:
+        claimName: {{.NewPVC}}

--- a/pkg/diskscaler/service.go
+++ b/pkg/diskscaler/service.go
@@ -67,10 +67,11 @@ func NewDiskScalerService(clientConfig *rest.Config,
 	resizeAll bool,
 	auditMode bool,
 	kubecostSvc *pvsizingrecommendation.KubecostService,
-	excludedNamespaces []string) (*DiskScalerService, error) {
+	excludedNamespaces []string,
+	version string) (*DiskScalerService, error) {
 	// To-DO :fill it via kubecost API
 	clusterID := "localCluster"
-	ds, err := NewDiskScaler(clientConfig, k8sClient, dynamicK8sClient, clusterID, kubecostSvc, auditMode)
+	ds, err := NewDiskScaler(clientConfig, k8sClient, dynamicK8sClient, clusterID, kubecostSvc, auditMode, version)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create NewDiskScaler: %w", err)
 	}
@@ -204,12 +205,12 @@ func (dss *DiskScalerService) startAutomatedScaling() error {
 			if dss.auditMode {
 				return
 			}
-			log.Debug().Msgf("status at %s :%+v, triggered the disk scaling", diskAutoScalerRun, status)
+			log.Info().Msgf("status at %s :%+v, triggered the disk scaling", diskAutoScalerRun, status)
 			if status.NumEnabled == 0 {
-				log.Debug().Msgf("No workloads have autoscaling enabled at %s", diskAutoScalerRun)
+				log.Info().Msgf("No workloads have autoscaling enabled at %s", diskAutoScalerRun)
 			}
 			if status.NumEligible == 0 {
-				log.Debug().Msgf("No workload with autoscaling eligible at %s", diskAutoScalerRun)
+				log.Info().Msgf("No workload with autoscaling eligible at %s", diskAutoScalerRun)
 			}
 		}
 	}()

--- a/pkg/diskscaler/setup.go
+++ b/pkg/diskscaler/setup.go
@@ -18,7 +18,7 @@ const (
 	KubecostNamespace = "kubecost"
 )
 
-func Setup(mux *http.ServeMux, clientConfig *rest.Config, k8sClient kubernetes.Interface, dynamicK8sClient *dynamic.DynamicClient) error {
+func Setup(mux *http.ServeMux, clientConfig *rest.Config, k8sClient kubernetes.Interface, dynamicK8sClient *dynamic.DynamicClient, version string) error {
 	costModelPath, err := getDiskScalerCostModelPath()
 	if len(costModelPath) == 0 {
 		return fmt.Errorf("setup of Disk Auto Scaler failed: %w", err)
@@ -47,7 +47,7 @@ func Setup(mux *http.ServeMux, clientConfig *rest.Config, k8sClient kubernetes.I
 	}
 
 	recommendationSvc := pvsizingrecommendation.NewKubecostService(costModelPath)
-	dss, err := NewDiskScalerService(clientConfig, k8sClient, dynamicK8sClient, resizeAll, auditMode, recommendationSvc, excludedNamespaces)
+	dss, err := NewDiskScalerService(clientConfig, k8sClient, dynamicK8sClient, resizeAll, auditMode, recommendationSvc, excludedNamespaces, version)
 	if err != nil {
 		return fmt.Errorf("failed to create disk scaler service: %w", err)
 	}


### PR DESCRIPTION
## What does this PR change?

- [ ] Uses cgr.dev/chainguard/wolfi-base:latest image
- [ ] Introduce Pod security standard of Restricted profile
- [ ] Adds standard label to the copier pod
- [ ] Moves the information about disk auto scaler operation from debug log level to info as info is default level

## Does this PR rely on any other PRs?
None

## How does this PR impact users?
Better security profile for the intermediate copier pod

## Links to Issues or tickets this PR addresses or fixes
Closes #8 
<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->


## What risks are associated with merging this PR? What is required to fully test this PR?
It was tested for scale up and scale down operation

The pod that gets created has following yaml 

`apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: "2024-05-22T23:18:14Z"
  deletionGracePeriodSeconds: 30
  deletionTimestamp: "2024-05-22T23:18:56Z"
  labels:
    app.kubernetes.io/component: copy-pod
    app.kubernetes.io/instance: kubecost-data-mover-pod-lonjx
    app.kubernetes.io/managed-by: kubecost-disk-autoscaler
    app.kubernetes.io/name: kubecost-data-mover-pod
    app.kubernetes.io/part-of: kubecost-disk-autoscaler
    app.kubernetes.io/version: ""
  name: kubecost-data-mover-pod-lonjx
  namespace: disk-scaler-demo
  resourceVersion: "89982731"
  uid: be70a682-7e35-40c1-8ada-222e8ef0b554
spec:
  containers:
  - args:
    - sleep infinity
    command:
    - /bin/sh
    - -c
    - --
    image: cgr.dev/chainguard/wolfi-base:latest
    imagePullPolicy: Always
    name: temp-container
    resources: {}
    securityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop:
        - ALL
      readOnlyRootFilesystem: true
      runAsNonRoot: true
      seccompProfile:
        type: RuntimeDefault
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /oldData
      name: orig-vol-mount
    - mountPath: /newData
      name: backup-vol-mount
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access-q9vz4
      readOnly: true
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  nodeName: ip-192-168-149-220.us-east-2.compute.internal
  preemptionPolicy: PreemptLowerPriority
  priority: 0
  restartPolicy: Always
  schedulerName: default-scheduler
  securityContext:
    runAsNonRoot: true
    runAsUser: 1000
    seccompProfile:
      type: RuntimeDefault
  serviceAccount: default
  serviceAccountName: default
  terminationGracePeriodSeconds: 30
  tolerations:
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 300
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 300
  volumes:
  - name: orig-vol-mount
    persistentVolumeClaim:
      claimName: test-pvc
  - name: backup-vol-mount
    persistentVolumeClaim:
      claimName: test-pvc-iylfc
  - name: kube-api-access-q9vz4
    projected:
      defaultMode: 420
      sources:
      - serviceAccountToken:
          expirationSeconds: 3607
          path: token
      - configMap:
          items:
          - key: ca.crt
            path: ca.crt
          name: kube-root-ca.crt
      - downwardAPI:
          items:
          - fieldRef:
              apiVersion: v1
              fieldPath: metadata.namespace
            path: namespace
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2024-05-22T23:18:24Z"
    status: "True"
    type: PodReadyToStartContainers
  - lastProbeTime: null
    lastTransitionTime: "2024-05-22T23:18:19Z"
    status: "True"
    type: Initialized
  - lastProbeTime: null
    lastTransitionTime: "2024-05-22T23:18:24Z"
    status: "True"
    type: Ready
  - lastProbeTime: null
    lastTransitionTime: "2024-05-22T23:18:24Z"
    status: "True"
    type: ContainersReady
  - lastProbeTime: null
    lastTransitionTime: "2024-05-22T23:18:19Z"
    status: "True"
    type: PodScheduled
  containerStatuses:
  - containerID: containerd://4d91c09e5880bede5bccfd3ee1ee7e082dbcd659bfc7d321ec30a52f484332b8
    image: cgr.dev/chainguard/wolfi-base:latest
    imageID: cgr.dev/chainguard/wolfi-base@sha256:d8386fa1d2ebddb69689fdb639817004d1ba97ce358e26ff06a8c21e02fc11ae
    lastState: {}
    name: temp-container
    ready: true
    restartCount: 0
    started: true
    state:
      running:
        startedAt: "2024-05-22T23:18:24Z"
  hostIP: 192.168.149.220
  hostIPs:
  - ip: 192.168.149.220
  phase: Running
  podIP: 192.168.131.77
  podIPs:
  - ip: 192.168.131.77
  qosClass: BestEffort
  startTime: "2024-05-22T23:18:19Z"`
## How was this PR tested?
Creating two deployments and waiting on kubecost to recommend and then letting the DIsk auto scaler do its respective function.

