### PR TITLE
switch to SPDX SBOM

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,21 +55,21 @@ jobs:
       run: |
         gcloud --quiet auth configure-docker
 
-    - name: Publish image and SBOM (CycloneDX)
+    - name: Publish image and SBOM (SPDX)
       id: ko-build
       # IMAGE will be in format <registry>/<org>/<repo>@<digest> ex ghcr.io/johndoe/redis@sha256:1b85db3f261af51914867eeda20a25bedf72fa406619bcdd60f0658f27b2722d
       run: |
         tag=$(echo ${{ github.ref }} | cut -c11-)
         export VERSION=$tag
         export COMMIT_HASH=${{ github.sha }}
-        IMAGE=$(ko build ./cmd/diskautoscaler --bare -t latest -t ${{ github.sha }} -t ${tag} --sbom=cyclonedx --sbom-dir=./)
+        IMAGE=$(ko build ./cmd/diskautoscaler --bare -t latest -t ${{ github.sha }} -t ${tag} --sbom=spdx --sbom-dir=./)
         echo "The image generated is: $IMAGE"
         echo "## Image summary" >> $GITHUB_STEP_SUMMARY
         echo "Built image: $IMAGE" >> $GITHUB_STEP_SUMMARY
         echo "IMAGE=$IMAGE" >> $GITHUB_ENV
         echo "image=$IMAGE" >> $GITHUB_OUTPUT
         echo "Renaming output SBOM file to sbom.json."
-        for file in *.cyclonedx.json; do
+        for file in *.spdx.json; do
           mv -- "$file" "sbom.json"
           break # Only rename the first file
         done
@@ -215,7 +215,7 @@ jobs:
 
     - name: Attest SBOM
       run: |
-        cosign attest --predicate sbom.json --type cyclonedx ${{ env.IMAGE }} -y
+        cosign attest --predicate sbom.json --type spdxjson ${{ env.IMAGE }} -y
         echo "Image SBOM attested: :heavy_check_mark:" >> $GITHUB_STEP_SUMMARY
 
     - name: Attest Scan


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

Switches SBOM format from CycloneDX to SPDX because ko removed support for CycloneDX and now only has SPDX. This was caused by https://github.com/ko-build/ko/pull/1333.

## Does this PR rely on any other PRs?

No

## How does this PR impact users?

None, CI only.

## Links to Issues or tickets this PR addresses or fixes

Caused by https://github.com/ko-build/ko/pull/1333


## What risks are associated with merging this PR? What is required to fully test this PR?

Releaser could still fail. Will be addressed.


## How was this PR tested?

Untested. Will be tested in a release workflow once merged.
