### PR TITLE
use Trivy db mirror

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -126,8 +126,10 @@ jobs:
       IMAGE: "${{ needs.build.outputs.image }}"
     steps:
     - name: Scan for vulnerabilities
-      uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.20.0 (Trivy v0.51.1)
-      with: 
+      uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0 (Trivy v0.56.1)
+      env:
+        TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+      with:
         image-ref: ${{ env.IMAGE }}
         format: cosign-vuln
         ignore-unfixed: true


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

Updates the scan step based on Trivy to add a vuln database mirror repository in AWS to avoid rate limiting. Further details at https://github.com/aquasecurity/trivy-action/issues/389.

## Does this PR rely on any other PRs?

No

## How does this PR impact users?

None, CI only.

## Links to Issues or tickets this PR addresses or fixes

See https://github.com/aquasecurity/trivy-action/issues/389


## What risks are associated with merging this PR? What is required to fully test this PR?

Releaser could fail. Will be addressed.

## How was this PR tested?

To be tested in CI.