### PR TITLE
update SBOM verification step to switch type to SPDX

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -72,10 +72,10 @@ slsa-verifier verify-image gcr.io/kubecost1/disk-autoscaler@<digest> --source-ur
 
 ## Verify SBOM
 
-Use the [Sigstore cosign](https://github.com/sigstore/cosign) tool to verify a software bill of materials (SBOM), using the [CycloneDX](https://cyclonedx.org/) standard, has been attested using the [keyless method](https://docs.sigstore.dev/signing/overview/).
+Use the [Sigstore cosign](https://github.com/sigstore/cosign) tool to verify a software bill of materials (SBOM), using the [SPDX](https://spdx.dev/) standard, has been attested using the [keyless method](https://docs.sigstore.dev/signing/overview/).
 
 ```sh
-cosign verify-attestation --type cyclonedx gcr.io/kubecost1/disk-autoscaler:$TAG --certificate-identity-regexp="https://github.com/kubecost/disk-autoscaler/.github/workflows/release.yaml@refs/tags/*" --certificate-oidc-issuer="https://token.actions.githubusercontent.com" | jq .payload -r | base64 --decode | jq
+cosign verify-attestation --type spdxjson gcr.io/kubecost1/disk-autoscaler:$TAG --certificate-identity-regexp="https://github.com/kubecost/disk-autoscaler/.github/workflows/release.yaml@refs/tags/*" --certificate-oidc-issuer="https://token.actions.githubusercontent.com" | jq .payload -r | base64 --decode | jq
 ```
 
 The SBOM is also available as an offline release asset for every tagged release.


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

Updates the security instructions in the Verify SBOM section with latest changes as of 0.0.20 release which changes the SBOM format from CycloneDX to SPDX due to ko's removal of the former.

## Does this PR rely on any other PRs?

No, but relates to changes made in #74.

## How does this PR impact users?

Provides users with accurate steps on how to verify the SBOM on their end.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->

Relates to #74.

## What risks are associated with merging this PR? What is required to fully test this PR?

Docs do not specify test procedures for releases < 0.0.20.

## How was this PR tested?

Commands tested locally on 0.0.20.